### PR TITLE
Improve error handling on new client creation.

### DIFF
--- a/src/socket_epoll.c
+++ b/src/socket_epoll.c
@@ -42,8 +42,10 @@ static int socket_event(struct epoll_event *events, int notified, redis_handler_
 
             addr_client_len = sizeof(addr_client);
 
-            if((clientfd = accept(redis->mainfd, (struct sockaddr *)&addr_client, &addr_client_len)) == -1)
+            if((clientfd = accept(redis->mainfd, (struct sockaddr *)&addr_client, &addr_client_len)) == -1) {
                 warnp("accept");
+                continue;
+            }
 
             socket_nonblock(clientfd);
             socket_client_new(clientfd);
@@ -59,8 +61,10 @@ static int socket_event(struct epoll_event *events, int notified, redis_handler_
             event.data.fd = clientfd;
             event.events = EPOLLIN;
 
-            if(epoll_ctl(redis->evfd, EPOLL_CTL_ADD, clientfd, &event) < 0)
+            if(epoll_ctl(redis->evfd, EPOLL_CTL_ADD, clientfd, &event) < 0) {
                 warnp("epoll_ctl");
+                continue;
+            }
 
             continue;
         }

--- a/src/socket_kqueue.c
+++ b/src/socket_kqueue.c
@@ -42,8 +42,10 @@ static int socket_event(struct kevent *events, int notified, redis_handler_t *re
 
             addr_client_len = sizeof(addr_client);
 
-            if((clientfd = accept(redis->mainfd, (struct sockaddr *)&addr_client, &addr_client_len)) == -1)
+            if((clientfd = accept(redis->mainfd, (struct sockaddr *)&addr_client, &addr_client_len)) == -1) {
                 warnp("accept");
+                continue;
+            }
 
             socket_nonblock(clientfd);
             socket_client_new(clientfd);
@@ -52,8 +54,10 @@ static int socket_event(struct kevent *events, int notified, redis_handler_t *re
             verbose("[+] incoming connection from %s (socket %d)\n", clientip, clientfd);
 
             EV_SET(&evset, clientfd, EVFILT_READ, EV_ADD, 0, 0, NULL);
-            if(kevent(redis->evfd, &evset, 1, NULL, 0, NULL) == -1)
-                diep("kevent");
+            if(kevent(redis->evfd, &evset, 1, NULL, 0, NULL) == -1) {
+                warnp("kevent");
+                continue;
+            }
 
             continue;
         }


### PR DESCRIPTION
- `continue` the loop when `accept` failed
- explicitly `continue` the loop when failed to add to epoll/kqueue set
- do not die when failed to add to kqueue set