### PR TITLE
Fix password checking in 'SELECT'.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -631,7 +631,7 @@ static int command_select(resp_request_t *request) {
             writable = 0;
 
         } else {
-            if(strncmp(request->argv[2]->buffer, namespace->password, request->argv[2]->length) != 0) {
+            if(strncmp(request->argv[2]->buffer, namespace->password, strlen(namespace->password)) != 0) {
                 redis_hardsend(request->client->fd, "-Access denied");
                 return 1;
             }

--- a/src/commands.c
+++ b/src/commands.c
@@ -602,7 +602,6 @@ static int command_select(resp_request_t *request) {
     // get name as usable string
     sprintf(target, "%.*s", request->argv[1]->length, (char *) request->argv[1]->buffer);
 
-
     // checking for existing namespace
     if(!(namespace = namespace_get(target))) {
         debug("[-] command: select: namespace not found\n");
@@ -631,7 +630,19 @@ static int command_select(resp_request_t *request) {
             writable = 0;
 
         } else {
-            if(strncmp(request->argv[2]->buffer, namespace->password, strlen(namespace->password)) != 0) {
+            char password[256];
+
+            if(request->argv[2]->length > (ssize_t) sizeof(password) - 1) {
+                redis_hardsend(request->client->fd, "-Password too long");
+                return 1;
+            }
+
+            // copy password to a temporary variable
+            // to check password match using strcmp and no any strncmp
+            // to ensure we check exact password
+            sprintf(password, "%.*s", request->argv[2]->length, (char *) request->argv[2]->buffer);
+
+            if(strcmp(password, namespace->password) != 0) {
                 redis_hardsend(request->client->fd, "-Access denied");
                 return 1;
             }

--- a/src/namespace.c
+++ b/src/namespace.c
@@ -127,7 +127,7 @@ static void namespace_descriptor_load(namespace_t *namespace) {
     namespace->public = (header.flags & NS_FLAGS_PUBLIC);
 
     if(header.passlength) {
-        if(!(namespace->password = malloc(sizeof(char) * header.passlength))) {
+        if(!(namespace->password = calloc(sizeof(char), header.passlength + 1))) {
             warnp("namespace password malloc");
             return;
         }


### PR DESCRIPTION
We currently could bypass the password by simply give use `""` as password
```bash
127.0.0.1:12345> SELECT thedisk
OK
127.0.0.1:12345> SET a 1
(error) Namespace is in read-only mode
127.0.0.1:12345> SELECT thedisk ""
OK
127.0.0.1:12345> SET a 1
"\x04\x00\x00\x00"
```

The length given to `strncmp` should be length of the stored
password, not length of given password.

