### PR TITLE
Support async response (closes #29)

### DIFF
--- a/src/commands_dataset.c
+++ b/src/commands_dataset.c
@@ -38,7 +38,7 @@ int command_exists(redis_client_t *client) {
     char response[32];
     sprintf(response, ":%d\r\n", found);
 
-    redis_reply(client, response, strlen(response));
+    redis_reply_stack(client, response, strlen(response));
 
     return 0;
 }
@@ -85,7 +85,7 @@ int command_check(redis_client_t *client) {
     char response[32];
     sprintf(response, ":%d\r\n", status);
 
-    redis_reply(client, response, strlen(response));
+    redis_reply_stack(client, response, strlen(response));
 
     return 0;
 }

--- a/src/commands_get.c
+++ b/src/commands_get.c
@@ -124,9 +124,8 @@ int command_get(redis_client_t *client) {
         return 0;
     }
 
-    redis_reply(client, response.buffer, response.length);
+    redis_reply(client, response.buffer, response.length, free);
 
-    free(response.buffer);
     free(payload.buffer);
 
     return 0;

--- a/src/commands_namespace.c
+++ b/src/commands_namespace.c
@@ -144,7 +144,7 @@ int command_nslist(redis_client_t *client) {
 
     // streaming list to the client
     sprintf(line, "*%lu\r\n", nsroot->length);
-    redis_reply(client, line, strlen(line));
+    redis_reply_stack(client, line, strlen(line));
 
     debug("[+] command: nslist: sending %lu items\n", nsroot->length);
 
@@ -153,7 +153,7 @@ int command_nslist(redis_client_t *client) {
         namespace_t *ns = nsroot->namespaces[i];
 
         sprintf(line, "$%ld\r\n%s\r\n", strlen(ns->name), ns->name);
-        redis_reply(client, line, strlen(line));
+        redis_reply_stack(client, line, strlen(line));
     }
 
     return 0;
@@ -202,7 +202,7 @@ int command_nsinfo(redis_client_t *client) {
         return 0;
     }
 
-    redis_reply(client, response.buffer, response.length);
+    redis_reply_stack(client, response.buffer, response.length);
 
     free(response.buffer);
 
@@ -307,7 +307,7 @@ int command_dbsize(redis_client_t *client) {
     char response[64];
 
     sprintf(response, ":%lu\r\n", client->ns->index->entries);
-    redis_reply(client, response, strlen(response));
+    redis_reply_stack(client, response, strlen(response));
 
     return 0;
 }

--- a/src/commands_scan.c
+++ b/src/commands_scan.c
@@ -38,7 +38,7 @@ static int command_scan_send_array(data_entry_header_t *header, redis_client_t *
     offset += header->idlength;
     offset += sprintf(response + offset, "\r\n");
 
-    redis_reply(client, response, offset);
+    redis_reply_stack(client, response, offset);
 
     return 0;
 }

--- a/src/commands_set.c
+++ b/src/commands_set.c
@@ -66,8 +66,7 @@ static size_t redis_set_handler_userkey(redis_client_t *client) {
         return 0;
     }
 
-    redis_reply(client, response.buffer, response.length);
-    free(response.buffer);
+    redis_reply(client, response.buffer, response.length, free);
 
     return offset;
 }
@@ -125,8 +124,7 @@ static size_t redis_set_handler_sequential(redis_client_t *client) {
         return 0;
     }
 
-    redis_reply(client, response.buffer, response.length);
-    free(response.buffer);
+    redis_reply(client, response.buffer, response.length, free);
 
     return offset;
 }
@@ -189,8 +187,7 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
         return 0;
     }
 
-    redis_reply(client, response.buffer, response.length);
-    free(response.buffer);
+    redis_reply(client, response.buffer, response.length, free);
 
     return offset;
 }

--- a/src/commands_system.c
+++ b/src/commands_system.c
@@ -37,7 +37,7 @@ int command_time(redis_client_t *client) {
     // [usec]         \r\n  -- second value payload
     sprintf(response, "*2\r\n$%lu\r\n%s\r\n$%lu\r\n%s\r\n", strlen(sec), sec, strlen(usec), usec);
 
-    redis_reply(client, response, strlen(response));
+    redis_reply_stack(client, response, strlen(response));
 
     return 0;
 }

--- a/src/redis.c
+++ b/src/redis.c
@@ -65,61 +65,41 @@ static void buffer_free(buffer_t *buffer) {
 // redis socket response
 //
 // we use non-blocking socket for all clients
-// since sending response to (slow) client can takes more than one send call
-// we need a way to deal with theses slow clients without loosing performance
+//
+// since sending response to client can takes more than one send call
+// we need a way to deal with theses clients without loosing performance
 // for the others client connected, and threading or anything parallele execution
 // is prohibed by design in this project
 //
+// in the function redis_reply, the workflow is documented
+// basicly, if we can't send data (because of EAGAIN), we wait the socket
+// to be ready later, by the main poll system
 //
-//
-// int redis_reply(redis_client_t *client, void *payload, size_t length, void (*destructor)(void *target)) {
-int redis_reply(redis_client_t *client, void *payload, size_t length, void (*destructor)(void *payload)) {
+static void redis_send_reset(redis_client_t *client) {
     redis_response_t *response = &client->response;
 
-    // for now, in any case we put the response
-    // in the response queue and waits for the kernel
-    // to trigger the write operator
-    //
-    // this could be optimized by trying to send anyway the payload
-    // and only copy/duplicate non-freeable payload if we could not
-    // send data because now every stack allocated or literal string
-    // will be duplicated
-    if(destructor) {
-        response->destructor = destructor;
-        response->buffer = payload;
+    if(response->destructor)
+        response->destructor(response->buffer);
 
-    } else {
-        if(!(response->buffer = malloc(length))) {
-            warnp("[-] redis_reply: malloc");
-            return 0;
-        }
-
-        response->destructor = free;
-        memcpy(response->buffer, payload, length);
-    }
-
-    response->reader = response->buffer;
-    response->length = length;
-
-    return 0;
-}
-
-inline int redis_reply_stack(redis_client_t *client, void *payload, size_t length) {
-    return redis_reply(client, payload, length, NULL);
+    response->buffer = NULL;
+    response->reader = NULL;
+    response->length = 0;
 }
 
 int redis_send_reply(redis_client_t *client) {
-    ssize_t sent;
     redis_response_t *response = &client->response;
+    ssize_t sent;
 
     while(response->length > 0) {
         debug("[+] redis: sending reply to %d (%ld bytes remains)\n", client->fd, response->length);
 
         if((sent = send(client->fd, response->reader, response->length, 0)) < 0) {
             if(errno != EAGAIN) {
-                perror("[-] redis: reply");
+                warnp("redis_send_reply, send");
                 return errno;
             }
+
+            debug("[-] redis: send: client %d is not ready for the send\n", client->fd);
 
             // we still have some data to send, which could not
             // be sent because the socket is not ready, and we are in
@@ -128,7 +108,7 @@ int redis_send_reply(redis_client_t *client) {
             // we don't change anything to the buffer
             // and we wait the next trigger from the polling system
             // to ask us the write is available again
-            return 0;
+            return errno;
         }
 
         response->reader += sent;
@@ -137,12 +117,81 @@ int redis_send_reply(redis_client_t *client) {
 
     // the buffer was fully sent, let's clean everything
     // which was related to this
-    response->destructor(response->buffer);
-    response->buffer = NULL;
-    response->reader = NULL;
-    response->length = 0;
+    debug("[+] redis: send: buffer sucessfully sent\n");
+    redis_send_reset(client);
 
     return 0;
+}
+
+int redis_reply(redis_client_t *client, void *payload, size_t length, void (*destructor)(void *payload)) {
+    redis_response_t *response = &client->response;
+
+    // preparing this request, using argument provided
+    // even if buffer are literal or stack allocated, we will try to send it
+    // a first time before choosing what to do
+    response->destructor = destructor;
+    response->buffer = payload;
+    response->reader = payload;
+    response->length = length;
+
+    debug("[+] redis: force sending first chunk (client %d)\n", client->fd);
+    if(redis_send_reply(client) != EAGAIN) {
+        // no EAGAIN and no buffer set, the send request
+        // was sucessful, nothing more to do since everything was
+        // already cleaned by redis_send_reply
+        if(response->buffer == NULL)
+            return 0;
+
+        // something went wrong during the send call
+        // and it was not a EAGAIN, this is a real error
+        // let's clean everything and drop this request
+        debug("[-] redis: something went wrong while sending, discarding\n");
+        redis_send_reset(client);
+    }
+
+    // if we are here, we hit a EAGAIN, this could occures for different
+    // reasons:
+    //  - the buffer to send is too big to be sent in one shot
+    //  - the client is not ready to receive data right now
+    //
+    // since we are full non-blocking socket, we don't want to block
+    // the others clients waiting this client is ready
+    //
+    // this function allows buffer allocated on the heap with a specific
+    // destructor in argument, for theses call there is nothing special to
+    // do, but this function can also accepts buffer which was stack allocated
+    // or even a literal string, in this case, when we will returns, theses
+    // pointers are not safe anymore and we can't reach them.
+    //
+    // if no destructor was provided, we will duplicate the buffer in order to
+    // keep it safe and send it later
+    debug("[+] redis: reply: client %d not ready for sending data\n", client->fd);
+
+    // destructor was set, nothing more to do, everything is already set
+    if(destructor)
+        return 0;
+
+    debug("[+] redis: duplicating data since it was a stack response\n");
+
+    // a destructor was set, we duplicate the buffer to the heap
+    if(!(response->buffer = malloc(response->length))) {
+        warnp("redis_reply: malloc");
+        return 0;
+    }
+
+    // we copy from the response and not the argument of these function
+    // because some data could be already be sent, and redis_send_reply has
+    // updated the response already
+    memcpy(response->buffer, response->reader, response->length);
+
+    response->destructor = free;
+    response->reader = response->buffer;
+
+    return 0;
+}
+
+inline int redis_reply_stack(redis_client_t *client, void *payload, size_t length) {
+    return redis_reply(client, payload, length, NULL);
 }
 
 //
@@ -506,6 +555,8 @@ redis_client_t *socket_client_new(int fd) {
         warnp("new client request malloc");
         return NULL;
     }
+
+    memset(&client->response, 0x00, sizeof(redis_response_t));
 
     client->request->state = RESP_EMPTY;
     client->request->argc = 0;

--- a/src/redis.h
+++ b/src/redis.h
@@ -10,7 +10,7 @@
     //
     // sizeof(message) will contains the null character, to append \r\n the size will
     // just be +1
-    #define redis_hardsend(fd, message) redis_reply(fd, message "\r\n", sizeof(message) + 1)
+    #define redis_hardsend(fd, message) redis_reply_stack(fd, message "\r\n", sizeof(message) + 1)
 
     //
     // redis protocol oriented objects
@@ -71,6 +71,18 @@
 
     } buffer_t;
 
+    typedef struct redis_response_t {
+        void *buffer;  // begin of the buffer which will be free's
+        void *reader;  // current pointer on the buffer, for the next chunk to send
+        size_t length; // length of the remain payload to send
+
+        // pointer to a desctuctor function which will be
+        // called when the send if fully complete, to clean
+        // the buffer
+        void (*destructor)(void *target);
+
+    } redis_response_t;
+
     // represent one client in memory
     typedef struct redis_client_t {
         int fd;           // socket file descriptor
@@ -84,6 +96,11 @@
         // each client will be attached to a request
         // this request will contains one-per-one commands
         resp_request_t *request;
+
+        // each client will have some (optional) pending
+        // write, we attach a delayed async writer per
+        // client
+        redis_response_t response;
 
     } redis_client_t;
 
@@ -117,7 +134,8 @@
     } redis_bulk_t;
 
     int redis_listen(char *listenaddr, int port, char *socket);
-    resp_status_t redis_chunk(int fd);
+    resp_status_t redis_chunk_read(int fd);
+    resp_status_t redis_delayed_write(int fd);
 
     void socket_nonblock(int fd);
     void socket_block(int fd);
@@ -134,5 +152,6 @@
     void socket_client_free(int fd);
 
     // socket generic reply
-    int redis_reply(redis_client_t *client, void *payload, size_t length);
+    int redis_reply(redis_client_t *client, void *payload, size_t length, void (*destructor)(void *target));
+    int redis_reply_stack(redis_client_t *client, void *payload, size_t length);
 #endif


### PR DESCRIPTION
Provide a way to delayed write to client if a single `send()` is not enough, without blocking the others clients.

- [x] Support async write
- [x] Support epoll
- [x] Support kqueue