### PR TITLE
Change direct mode to use index as intermediate layer

### DIFF
--- a/src/commands_get.c
+++ b/src/commands_get.c
@@ -34,8 +34,11 @@ static index_entry_t *redis_get_handler_direct(redis_client_t *client) {
     memcpy(&directkey, request->argv[1]->buffer, sizeof(index_dkey_t));
     memcpy(index_reusable_entry->id, request->argv[1]->buffer, sizeof(index_dkey_t));
 
+    debug("[+] command: get: direct [%d, %d]\n", directkey.indexid, directkey.objectid);
+
     // extract needed data
     size_t offset = index_offset_objectid(directkey.objectid);
+    debug("[+] command: get: resolved [%d, %lu]\n", directkey.indexid, offset);
 
     // request index entry from disk
     index_root_t *index = client->ns->index;

--- a/src/commands_get.c
+++ b/src/commands_get.c
@@ -35,10 +35,11 @@ static index_entry_t *redis_get_handler_direct(redis_client_t *client) {
     memcpy(index_reusable_entry->id, request->argv[1]->buffer, sizeof(index_dkey_t));
 
     index_reusable_entry->idlength = sizeof(index_dkey_t);
-    index_reusable_entry->offset = directkey.offset;
+    index_reusable_entry->offset = index_offset_objectid(directkey.idobj);
     index_reusable_entry->dataid = directkey.dataid;
     index_reusable_entry->flags = 0;
 
+    #if 0
     // since the user can provide any offset, he could potentially
     // get data not expected and maybe get sensitive data
     //
@@ -61,6 +62,7 @@ static index_entry_t *redis_get_handler_direct(redis_client_t *client) {
     }
 
     index_reusable_entry->length = length;
+    #endif
 
     return index_reusable_entry;
 }

--- a/src/commands_set.c
+++ b/src/commands_set.c
@@ -162,11 +162,11 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
     data_root_t *data = client->ns->data;
 
     // create some easier accessor
-    index_dkey_t id = {
-        .dataid = data_dataid(data),      // current data fileid
-        .offset = data_next_offset(data), // needed now, we write it to the datafile
-    };
     uint8_t idlength = sizeof(index_dkey_t);
+    index_dkey_t id = {
+        .dataid = index_indexid(index),     // current index fileid
+        .offset = index_next_offset(index), // needed now, it's part of the id
+    };
 
     unsigned char *value = request->argv[2]->buffer;
     uint32_t valuelength = request->argv[2]->length;

--- a/src/commands_set.c
+++ b/src/commands_set.c
@@ -164,8 +164,8 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
     // create some easier accessor
     uint8_t idlength = sizeof(index_dkey_t);
     index_dkey_t id = {
-        .indexid = index_indexid(index),   // current index fileid
-        .objectid = index_next_id(index),  // needed now, it's part of the id
+        .indexid = index_indexid(index),        // current index fileid
+        .objectid = index_next_objectid(index), // needed now, it's part of the id
     };
 
     unsigned char *value = request->argv[2]->buffer;

--- a/src/commands_set.c
+++ b/src/commands_set.c
@@ -164,8 +164,8 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
     // create some easier accessor
     uint8_t idlength = sizeof(index_dkey_t);
     index_dkey_t id = {
-        .dataid = index_indexid(index),  // current index fileid
-        .idobj = index_next_id(index),   // needed now, it's part of the id
+        .indexid = index_indexid(index),   // current index fileid
+        .objectid = index_next_id(index),  // needed now, it's part of the id
     };
 
     unsigned char *value = request->argv[2]->buffer;

--- a/src/commands_set.c
+++ b/src/commands_set.c
@@ -164,8 +164,8 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
     // create some easier accessor
     uint8_t idlength = sizeof(index_dkey_t);
     index_dkey_t id = {
-        .dataid = index_indexid(index),     // current index fileid
-        .offset = index_next_offset(index), // needed now, it's part of the id
+        .dataid = index_indexid(index),  // current index fileid
+        .idobj = index_next_id(index),   // needed now, it's part of the id
     };
 
     unsigned char *value = request->argv[2]->buffer;
@@ -175,9 +175,7 @@ static size_t redis_set_handler_directkey(redis_client_t *client) {
 
     // insert the data on the datafile
     // this will returns us the offset where the header is
-    // size_t offset = data_insert(value, valuelength, id, idlength);
     size_t offset = data_insert(data, value, valuelength, &id, idlength);
-    id.offset = offset;
 
     // checking for writing error
     // if we couldn't write the data, we won't add entry on the index

--- a/src/data.c
+++ b/src/data.c
@@ -163,7 +163,7 @@ void data_initialize(char *filename, data_root_t *root) {
     data_header_t header;
 
     memcpy(header.magic, "DAT0", 4);
-    header.version = 1;
+    header.version = ZDB_DATAFILE_VERSION;
     header.created = time(NULL);
     header.opened = 0; // not supported yet
     header.fileid = root->dataid;

--- a/src/data.c
+++ b/src/data.c
@@ -430,6 +430,7 @@ int data_entry_is_deleted(data_entry_header_t *entry) {
     return (entry->flags & DATA_ENTRY_DELETED);
 }
 
+#if 0
 // this function will check for a legitime request inside the data set
 // to estimate if a request is legitimate, we assume that
 //  - if the offset provided point to a header
@@ -508,6 +509,7 @@ size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, 
 
     return length;
 }
+#endif
 
 int data_delete_real(int fd, size_t offset) {
     data_entry_header_t header;

--- a/src/data.h
+++ b/src/data.h
@@ -92,7 +92,8 @@
 
     data_payload_t data_get(data_root_t *root, size_t offset, size_t length, uint16_t dataid, uint8_t idlength);
     int data_check(data_root_t *root, size_t offset, uint16_t dataid);
-    size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, uint16_t dataid);
+
+    // size_t data_match(data_root_t *root, void *id, uint8_t idlength, size_t offset, uint16_t dataid);
 
     int data_delete(data_root_t *root, size_t offset, uint16_t dataid);
 

--- a/src/index.c
+++ b/src/index.c
@@ -120,7 +120,7 @@ uint64_t index_next_id(index_root_t *root) {
 }
 
 // perform the basic "hashing" (crc based) used to point to the expected branch
-// we only keep partial amount of the result to now fill the memory too fast
+// we only keep partial amount of the result to not fill the memory too fast
 static inline uint32_t index_key_hash(unsigned char *id, uint8_t idlength) {
     uint64_t *input = (uint64_t *) id;
     uint32_t hash = 0;
@@ -182,7 +182,7 @@ index_entry_t *index_entry_insert_memory(index_root_t *root, unsigned char *id, 
         return exists;
     }
 
-    // calloc will ensure any unset fields (eg: flags) to zero
+    // calloc will ensure any unset fields (eg: flags) are zero
     size_t entrysize = sizeof(index_entry_t) + idlength;
     index_entry_t *entry = calloc(entrysize, 1);
 
@@ -285,11 +285,26 @@ index_entry_t *index_entry_delete(index_root_t *root, index_entry_t *entry) {
     return entry;
 }
 
+// return the offset of the next entry which will be added
+// this could be needed, for exemple in direct key mode,
+// when the key depends of the offset itself
+size_t index_next_offset(index_root_t *root) {
+    return lseek(root->indexfd, 0, SEEK_END);
+}
+
+
+// return current fileid in use
+uint16_t index_indexid(index_root_t *root) {
+    return root->indexid;
+}
+
 // return 1 or 0 if index entry is deleted or not
 int index_entry_is_deleted(index_entry_t *entry) {
     return (entry->flags & INDEX_ENTRY_DELETED);
 }
 
+// iterate over all entries in a single branch
+// and remove if this entry is related to requested namespace
 static inline size_t index_clean_namespace_branch(index_branch_t *branch, void *namespace) {
     index_entry_t *entry = branch->list;
     index_entry_t *previous = NULL;

--- a/src/index.c
+++ b/src/index.c
@@ -114,7 +114,7 @@ size_t index_jump_next(index_root_t *root) {
 // index manipulation
 //
 uint64_t index_next_id(index_root_t *root) {
-    // this is only used on sequential-id
+    // this is used on sequential-id and direct-mode
     // it gives the next id
     return root->nextentry;
 }
@@ -301,6 +301,24 @@ uint16_t index_indexid(index_root_t *root) {
 // return 1 or 0 if index entry is deleted or not
 int index_entry_is_deleted(index_entry_t *entry) {
     return (entry->flags & INDEX_ENTRY_DELETED);
+}
+
+// returns offset in the indexfile from idobject
+size_t index_offset_objectid(uint32_t idobj) {
+    // skip index header
+    size_t offset = sizeof(index_t);
+
+    // index is linear like this
+    // [header][obj-1][obj-2][obj-3][...]
+    //
+    // object X offset can be found by computing
+    // size of each entry, in direct mode, keys are
+    // always fixed-length
+    //
+    //                       each entry          fixed-key-length
+    offset += (idobj * (sizeof(index_item_t) + sizeof(index_dkey_t)));
+
+    return offset;
 }
 
 // iterate over all entries in a single branch

--- a/src/index.c
+++ b/src/index.c
@@ -306,7 +306,7 @@ index_entry_t *index_entry_insert(index_root_t *root, void *vid, uint8_t idlengt
 }
 
 index_entry_t *index_entry_delete(index_root_t *root, index_entry_t *entry) {
-    /*
+    #if 0
     index_entry_t *entry = index_entry_get(root, id, idlength);
 
     if(!entry) {
@@ -318,7 +318,7 @@ index_entry_t *index_entry_delete(index_root_t *root, index_entry_t *entry) {
         verbose("[-] index: key already deleted\n");
         return NULL;
     }
-    */
+    #endif
 
     // mark entry as deleted
     entry->flags |= INDEX_ENTRY_DELETED;

--- a/src/index.h
+++ b/src/index.h
@@ -115,7 +115,7 @@
     // key used by direct mode
     typedef struct index_dkey_t {
         uint16_t dataid;
-        uint32_t offset;
+        uint32_t idobj;
 
     } __attribute__((packed)) index_dkey_t;
 
@@ -147,5 +147,6 @@
     extern index_entry_t *index_reusable_entry;
 
     size_t index_next_offset(index_root_t *root);
+    size_t index_offset_objectid(uint32_t idobj);
     uint16_t index_indexid(index_root_t *root);
 #endif

--- a/src/index.h
+++ b/src/index.h
@@ -96,7 +96,8 @@
         char *indexfile;    // current index filename in use
         uint16_t indexid;   // current index file id in use (sync with data id)
         int indexfd;        // current file descriptor used
-        uint32_t nextentry; // next-entry is a global id used in sequential mode (next seq-id)
+        uint64_t nextentry; // next-entry is a global id used in sequential mode (next seq-id)
+        uint32_t nextid;    // next-id is a localfile id used in direct mode (next id on this file)
         int sync;           // flag to force write sync
         int synctime;       // force sync index after this amount of time
         time_t lastsync;    // keep track when the last sync was explictly made
@@ -125,7 +126,9 @@
 
     size_t index_jump_next(index_root_t *root);
     int index_emergency(index_root_t *root);
+
     uint64_t index_next_id(index_root_t *root);
+    uint32_t index_next_objectid(index_root_t *root);
 
     index_entry_t *index_entry_get(index_root_t *root, unsigned char *id, uint8_t length);
     index_item_t *index_item_get_disk(index_root_t *root, uint16_t indexid, size_t offset, uint8_t idlength);

--- a/src/index.h
+++ b/src/index.h
@@ -115,8 +115,8 @@
 
     // key used by direct mode
     typedef struct index_dkey_t {
-        uint16_t dataid;
-        uint32_t idobj;
+        uint16_t indexid;
+        uint32_t objectid;
 
     } __attribute__((packed)) index_dkey_t;
 
@@ -128,6 +128,8 @@
     uint64_t index_next_id(index_root_t *root);
 
     index_entry_t *index_entry_get(index_root_t *root, unsigned char *id, uint8_t length);
+    index_item_t *index_item_get_disk(index_root_t *root, uint16_t indexid, size_t offset, uint8_t idlength);
+
     index_entry_t *index_entry_insert(index_root_t *root, void *vid, uint8_t idlength, size_t offset, size_t length);
     index_entry_t *index_entry_insert_memory(index_root_t *root, unsigned char *id, uint8_t idlength, size_t offset, size_t length, uint8_t flags);
 

--- a/src/index.h
+++ b/src/index.h
@@ -145,4 +145,7 @@
 
     extern index_item_t *index_transition;
     extern index_entry_t *index_reusable_entry;
+
+    size_t index_next_offset(index_root_t *root);
+    uint16_t index_indexid(index_root_t *root);
 #endif

--- a/src/index_loader.c
+++ b/src/index_loader.c
@@ -268,6 +268,11 @@ static size_t index_load_file(index_root_t *root) {
     ssize_t ahead;
     index_item_t *entry = NULL;
 
+    // ensure nextid is zero, because this id
+    // is relative to the indexfile, we start to populate
+    // this file, starting from zero
+    root->nextid = 0;
+
     while(read(root->indexfd, &idlength, sizeof(idlength)) == sizeof(idlength)) {
         // we have the length of the key
         ssize_t entrylength = sizeof(index_item_t) + idlength;
@@ -386,6 +391,7 @@ index_root_t *index_init(settings_t *settings, char *indexdir, void *namespace, 
     root->indexid = 0;
     root->indexfile = malloc(sizeof(char) * (PATH_MAX + 1));
     root->nextentry = 0;
+    root->nextid = 0;
     root->sync = settings->sync;
     root->synctime = settings->synctime;
     root->lastsync = 0;

--- a/src/index_loader.c
+++ b/src/index_loader.c
@@ -102,7 +102,7 @@ index_t index_initialize(int fd, uint16_t indexid, index_root_t *root) {
     index_t header;
 
     memcpy(header.magic, "IDX0", 4);
-    header.version = 1;
+    header.version = ZDB_IDXFILE_VERSION;
     header.created = time(NULL);
     header.fileid = indexid;
     header.opened = time(NULL);
@@ -212,6 +212,16 @@ static size_t index_load_file(index_root_t *root) {
         header = index_initialize(root->indexfd, root->indexid, root);
     }
 
+    if(memcmp(header.magic, "IDX0", 4)) {
+        danger("[-] %s: invalid header, wrong magic", root->indexfile);
+        exit(EXIT_FAILURE);
+    }
+
+    if(header.version != ZDB_IDXFILE_VERSION) {
+        danger("[-] %s: unsupported version detected", root->indexfile);
+        danger("[-] file version: %d, supported version: %d", header.version, ZDB_IDXFILE_VERSION);
+        exit(EXIT_FAILURE);
+    }
 
     // re-writing the header, with updated data if the index is writable
     // if the file was just created, it's okay, we have a new struct ready

--- a/src/zerodb.h
+++ b/src/zerodb.h
@@ -10,6 +10,17 @@
     #define ZDB_DEFAULT_LISTENADDR  "0.0.0.0"
     #define ZDB_DEFAULT_PORT        9900
 
+    // define here version of datafile and indexfile
+    // theses version are written on header of each file created
+    //
+    // the version will only change (increment of 1) if the
+    // format of the binary struct change
+    //
+    // one version of 0-db will only support one version of file
+    // there no backward compatibility planed
+    //
+    // if some update are made, upgrade tools could be written
+    // to update existing database
     #define ZDB_DATAFILE_VERSION    2
     #define ZDB_IDXFILE_VERSION     2
 

--- a/src/zerodb.h
+++ b/src/zerodb.h
@@ -10,6 +10,9 @@
     #define ZDB_DEFAULT_LISTENADDR  "0.0.0.0"
     #define ZDB_DEFAULT_PORT        9900
 
+    #define ZDB_DATAFILE_VERSION    2
+    #define ZDB_IDXFILE_VERSION     2
+
     typedef enum db_mode_t {
         // default key-value store
         KEYVALUE = 0,

--- a/tools/index-dump.c
+++ b/tools/index-dump.c
@@ -67,6 +67,11 @@ int index_dump(int fd) {
         return 1;
     }
 
+    if(header.version != ZDB_IDXFILE_VERSION) {
+        fprintf(stderr, "[-] index version mismatch (%d <> %d)\n", header.version, ZDB_IDXFILE_VERSION);
+        return 1;
+    }
+
     printf("[+] index header seems correct\n");
 
     // now it's time to read each entries

--- a/tools/index-dump.c
+++ b/tools/index-dump.c
@@ -85,7 +85,7 @@ int index_dump(int fd) {
             diep("realloc");
 
         // rollback the 1 byte read for the id length
-        lseek(fd, -1, SEEK_CUR);
+        off_t curoff = lseek(fd, -1, SEEK_CUR);
 
         if(read(fd, entry, entrylength) != entrylength)
             diep("index header read failed");
@@ -94,7 +94,8 @@ int index_dump(int fd) {
 
         index_date(entry->timestamp, entrydate, sizeof(entrydate));
 
-        printf("[+] index entry: %lu, id length: %d\n", entrycount, entry->idlength);
+        printf("[+] index entry: %lu, offset: %lu\n", entrycount, curoff);
+        printf("[+]   id length  : %d\n", entry->idlength);
         printf("[+]   data length: %" PRIu64 "\n", entry->length);
         printf("[+]   data offset: %" PRIu64 "\n", entry->offset);
         printf("[+]   data fileid: %u\n", entry->dataid);

--- a/tools/integrity-check.c
+++ b/tools/integrity-check.c
@@ -66,6 +66,11 @@ int data_integrity(int fd) {
         return 1;
     }
 
+    if(header.version != ZDB_DATAFILE_VERSION) {
+        fprintf(stderr, "[-] version mismatch (%d <> %d)\n", header.version, ZDB_DATAFILE_VERSION);
+        return 1;
+    }
+
     printf("[+] data header seems correct\n");
 
     // now it's time to read each entries


### PR DESCRIPTION
In the beginning, direct mode was not using index at all. After a while, even this mode started using an index, at least just for statistics.

Performance was a little bit reduced but still quite good. Now, since we have the index anyway, let use it to make things really better.

Previously, direct mode was returning a binary key, with `dataid/offset` contents. This was enough to get data back but had some contraints:
- User could potentially craft an invalid request (some check was made to enforce this)
- Since position on the data is returned to the client, datafile cannot be changed, ever.

The last point is really important, this disallow compaction (or need to use sparse files).

**This change use the index as intermediate layer.**

The returned key is now `indexid/objectid`, object id is a count and not an offset:
- Each entry have a fixed-length id size, each entries will be the same size, we can point to an object id and compute it's real offset, we don't allows user to provide custom offset
- Index uses indirection to point to the datafile, we can now compact datafile and update index, without changing the key

Performance are not better, but not lower neither.

This closes #36 